### PR TITLE
Convert random number picker to ES6

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-function getRandom(minimum, maximum, integer = true) {
+const getRandom = (minimum, maximum, integer = true) => {
   const min = Math.ceil(minimum);
   const max = Math.floor(maximum);
   const random = Math.random() * (max - min);


### PR DESCRIPTION
For whatever reason the random number picker was not using the same syntax as the other functions, which are all ES6 fat arrow notation style.